### PR TITLE
feat: 增加 langfarm-io 模块：langfuse 的 api_keys 和 models 表读取。

### DIFF
--- a/packages/langfarm-io/README.md
+++ b/packages/langfarm-io/README.md
@@ -1,0 +1,6 @@
+# langfarm-io
+
+## langfuse
+
+* api_keys 和 models 表的信息读取。
+* api_key 的授权方法。

--- a/packages/langfarm-io/pyproject.toml
+++ b/packages/langfarm-io/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "langfarm-io"
+version = "0.1.0"
+description = "Langfarm IO"
+readme = "README.md"
+requires-python = ">=3.10"
+
+dependencies = [
+    "cachetools>=5.5.1",
+    "psycopg[binary]>=3.2.4",
+    "pydantic>=2.10.6",
+    # "langfarm-xxx"
+    "sqlalchemy>=2.0.37",
+]
+
+[dependency-groups]
+dev = []
+
+[tool.uv.sources]
+# langfarm-xxx = { workspace = true }
+
+[tool.ruff]
+extend = "../../pyproject.toml"
+include = ["src/**", "tests/*.py"]
+
+[tool.pyright]
+extends = "../../pyproject.toml"
+include = ["src", "tests"]
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+testpaths = ["tests"]

--- a/packages/langfarm-io/src/langfarm_io/langfuse/auth.py
+++ b/packages/langfarm-io/src/langfarm_io/langfuse/auth.py
@@ -1,0 +1,40 @@
+import base64
+import hashlib
+
+
+def decode_from_basic_auth(authorization: str) -> tuple[str | None, str | None]:
+    """
+    从 http 的 basic_auth 内容解码出 public key 和 secret key
+    :param authorization: http 的 basic_auth head 'authorization'
+    :return: (pk, sk)
+    """
+    pk = None
+    sk = None
+    auth = authorization.split(" ")
+    if len(auth) > 1:
+        auth = base64.b64decode(auth[1]).decode()
+        auth = auth.split(":")
+        pk = auth[0]
+        if len(auth) > 1:
+            sk = auth[1]
+    return pk, sk
+
+
+def fast_hashed_secret_key(secret_key: str, salt: str) -> str:
+    """
+    兼容 langfuse secret_key 的 hash 算法。
+    :param secret_key: langfuse 生成的 secret_key
+    :param salt: langfuse 的 'SALT' 环境变量
+    :return: fast hashed 的 secret_key 等同于 langfuse 的 api_keys.fast_hashed_secret_key 字段值。
+    """
+    # 计算 盐
+    _salt = hashlib.sha256()
+    _salt.update(salt.encode("utf-8"))
+    salt_hash = _salt.hexdigest()
+
+    # sk 加 盐
+    sk = hashlib.sha256()
+    sk.update(secret_key.encode())
+    sk.update(salt_hash.encode())
+
+    return sk.hexdigest()

--- a/packages/langfarm-io/src/langfarm_io/langfuse/crud.py
+++ b/packages/langfarm-io/src/langfarm_io/langfuse/crud.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+
+from cachetools import cached, TTLCache
+from sqlalchemy import select, or_, text, nullslast
+
+from langfarm_io.langfuse import auth
+from langfarm_io.langfuse import db_reader
+from langfarm_io.langfuse.schema import ApiKey, Model
+
+
+def select_api_key_by_pk_sk(pk: str, sk: str, salt: str) -> ApiKey | None:
+    fast_hashed_secret_key = auth.fast_hashed_secret_key(sk, salt)
+    stmt = select(ApiKey).where(ApiKey.fast_hashed_secret_key == fast_hashed_secret_key).where(ApiKey.public_key == pk)
+    api_key = db_reader.read_first(stmt, ApiKey)
+    return api_key
+
+
+def find_model(model: str, project_id: str, unit: str | None = None) -> Model | None:
+    start_time = datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S%z")
+    start_time_where = text(f"start_date <= '{start_time}'::timestamp with time zone at time zone 'UTC'")
+    stmt = (
+        select(Model)
+        .where(or_(Model.project_id == project_id, Model.project_id.is_(None)))
+        .where(text(":model ~ match_pattern").params({"model": model}))
+        .where(or_(start_time_where, Model.start_date.is_(None)))
+        .order_by(Model.project_id.asc())
+        .order_by(nullslast(Model.start_date.desc()))
+        .limit(1)
+    )
+
+    if unit:
+        stmt = stmt.where(Model.unit == unit)
+
+    model_obj = db_reader.read_first(stmt, Model)
+    return model_obj
+
+
+# 10 分钟 + 256 容量
+@cached(cache=TTLCache(maxsize=256, ttl=600), info=True)
+def get_api_key_by_cache(pk: str, sk: str, salt: str) -> ApiKey | None:
+    api_key = select_api_key_by_pk_sk(pk, sk, salt)
+    return api_key
+
+
+@cached(cache=TTLCache(maxsize=256, ttl=600), info=True)
+def find_model_by_cache(model_name: str, project_id: str, unit: str | None = None) -> Model | None:
+    return find_model(model_name, project_id, unit=unit)

--- a/packages/langfarm-io/src/langfarm_io/langfuse/db_reader.py
+++ b/packages/langfarm-io/src/langfarm_io/langfuse/db_reader.py
@@ -1,0 +1,49 @@
+import logging
+from collections.abc import Generator
+from typing import TypeVar, Optional, Type
+
+from sqlalchemy.orm import Session
+
+from langfarm_io.langfuse.schema import TableBase
+
+logger = logging.getLogger(__name__)
+
+engine = None
+
+
+def get_db_session() -> Generator[Session, None, None]:
+    session = Session(engine)
+    logger.debug("db session=[%s] created", session.hash_key)
+    try:
+        yield session
+    finally:
+        session.close()
+        logger.debug("db session=[%s] closed", session.hash_key)
+
+
+_T = TypeVar("_T", bound=TableBase)
+
+
+def with_db_session(func):
+    def execute(stmt, t: Type[_T]) -> Optional[_T] | Generator[_T, None, None]:
+        for session in get_db_session():
+            return func(stmt, t, session=session)
+
+    return execute
+
+
+@with_db_session
+def read_first(stmt, t: Type[_T], *, session: Session | None = None) -> Optional[_T]:
+    if session is None:
+        return None
+    row = session.execute(stmt).first()
+    return row[0] if row else None
+
+
+@with_db_session
+def read_list(stmt, t: Type[_T], *, session: Session | None = None) -> Generator[_T, None, None]:
+    if session is None:
+        return None
+    rows = session.execute(stmt).all()
+    for row in rows:
+        yield row[0]

--- a/packages/langfarm-io/src/langfarm_io/langfuse/local_cache.py
+++ b/packages/langfarm-io/src/langfarm_io/langfuse/local_cache.py
@@ -1,0 +1,29 @@
+import logging
+from pydantic import BaseModel
+
+from langfarm_io.langfuse.crud import get_api_key_by_cache, find_model_by_cache
+
+logger = logging.getLogger(__name__)
+
+named_caches = {"api_key": get_api_key_by_cache, "model": find_model_by_cache}
+
+
+class CacheInfo(BaseModel):
+    hits: int = 0
+    misses: int = 0
+    maxsize: int = 0
+    currsize: int = 0
+
+
+def _cache_info_to_obj(_cache_info) -> CacheInfo:
+    return CacheInfo(hits=_cache_info[0], misses=_cache_info[1], maxsize=_cache_info[2], currsize=_cache_info[3])
+
+
+def get_cache_info(_cache_handler, clear_cache: bool = False) -> CacheInfo:
+    info = _cache_info_to_obj(_cache_handler.cache_info())
+    if clear_cache:
+        _cache_handler.cache_clear()
+        after_info = _cache_info_to_obj(_cache_handler.cache_info())
+        logger.info("clear_cache[%s], before=%s, after=%s", _cache_handler.__name__, info, after_info)
+        info = after_info
+    return info

--- a/packages/langfarm-io/src/langfarm_io/langfuse/schema.py
+++ b/packages/langfarm-io/src/langfarm_io/langfuse/schema.py
@@ -1,0 +1,70 @@
+import datetime as dt
+
+from sqlalchemy import DateTime, Numeric, Text, UniqueConstraint, text
+from sqlalchemy.orm import DeclarativeBase, mapped_column
+from sqlalchemy.types import TypeDecorator
+
+
+class TZDateTime(TypeDecorator):
+    impl = DateTime
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):
+        if value is not None:
+            if not value.tzinfo or value.tzinfo.utcoffset(value) is None:
+                raise TypeError("tzinfo is required")
+            value = value.astimezone(dt.timezone.utc).replace(tzinfo=None)
+        return value
+
+    def process_result_value(self, value, dialect):
+        if value is not None:
+            value = value.replace(tzinfo=dt.timezone.utc).astimezone()
+        return value
+
+
+class TableBase(DeclarativeBase):
+    def to_dict(self):
+        return {c.name: getattr(self, c.name) for c in self.__table__.columns}
+
+
+class ApiKey(TableBase):
+    __tablename__ = "api_keys"
+    __table_args__ = (
+        UniqueConstraint("hashed_secret_key", name="uq_hashed_secret_key"),
+        UniqueConstraint("fast_hashed_secret_key", name="uq_fast_hashed_secret_key"),
+        UniqueConstraint("public_key", name="uq_public_key"),
+    )
+
+    id = mapped_column(Text, primary_key=True)
+    created_at = mapped_column(TZDateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=False)
+    note = mapped_column(Text)
+    public_key = mapped_column(Text, nullable=False, index=True)
+    hashed_secret_key = mapped_column(Text, nullable=False, index=True)
+    display_secret_key = mapped_column(Text, nullable=False)
+    last_used_at = mapped_column(TZDateTime)
+    expires_at = mapped_column(TZDateTime)
+    project_id = mapped_column(Text, nullable=False, index=True)
+    fast_hashed_secret_key = mapped_column(Text, index=True)
+
+
+class Model(TableBase):
+    __tablename__ = "models"
+    __table_args__ = (
+        UniqueConstraint(
+            "project_id", "model_name", "start_date", "unit", name="models_project_id_model_name_start_date_unit_key"
+        ),
+    )
+
+    id = mapped_column(Text, primary_key=True)
+    created_at = mapped_column(TZDateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=False)
+    updated_at = mapped_column(TZDateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=False)
+    project_id = mapped_column(Text)
+    model_name = mapped_column(Text, nullable=False, index=True)
+    match_pattern = mapped_column(Text, nullable=False)
+    start_date = mapped_column(TZDateTime)
+    input_price = mapped_column(Numeric)
+    output_price = mapped_column(Numeric)
+    total_price = mapped_column(Numeric)
+    unit = mapped_column(Text)
+    tokenizer_config = mapped_column(Text)
+    tokenizer_id = mapped_column(Text)

--- a/packages/langfarm-io/tests/langfuse/env_config.py
+++ b/packages/langfarm-io/tests/langfuse/env_config.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class LangfuseEnv(BaseModel):
+    SALT: str = "mysalt"
+    LANGFUSE_SECRET_KEY: str = "sk-lf-f69c6951-3462-4997-ba22-1c598e8308aa"
+    LANGFUSE_PUBLIC_KEY: str = "pk-lf-a82c2304-c8ee-4b24-aafc-f3d228ca336c"
+    PROJECT_ID: str = "cm6g0uptx000613r2ha6hxtkc"

--- a/packages/langfarm-io/tests/langfuse/init_db/api_keys.sql
+++ b/packages/langfarm-io/tests/langfuse/init_db/api_keys.sql
@@ -1,0 +1,91 @@
+-- Table: public.api_keys
+
+-- DROP TABLE IF EXISTS public.api_keys;
+
+CREATE TABLE IF NOT EXISTS public.api_keys
+(
+    id text COLLATE pg_catalog."default" NOT NULL,
+    created_at timestamp(3) without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    note text COLLATE pg_catalog."default",
+    public_key text COLLATE pg_catalog."default" NOT NULL,
+    hashed_secret_key text COLLATE pg_catalog."default" NOT NULL,
+    display_secret_key text COLLATE pg_catalog."default" NOT NULL,
+    last_used_at timestamp(3) without time zone,
+    expires_at timestamp(3) without time zone,
+    project_id text COLLATE pg_catalog."default" NOT NULL,
+    fast_hashed_secret_key text COLLATE pg_catalog."default",
+    CONSTRAINT api_keys_pkey PRIMARY KEY (id),
+    CONSTRAINT api_keys_project_id_fkey FOREIGN KEY (project_id)
+        REFERENCES public.projects (id) MATCH SIMPLE
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS public.api_keys
+    OWNER to test;
+-- Index: api_keys_fast_hashed_secret_key_idx
+
+-- DROP INDEX IF EXISTS public.api_keys_fast_hashed_secret_key_idx;
+
+CREATE INDEX IF NOT EXISTS api_keys_fast_hashed_secret_key_idx
+    ON public.api_keys USING btree
+    (fast_hashed_secret_key COLLATE pg_catalog."default" ASC NULLS LAST)
+    TABLESPACE pg_default;
+-- Index: api_keys_fast_hashed_secret_key_key
+
+-- DROP INDEX IF EXISTS public.api_keys_fast_hashed_secret_key_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS api_keys_fast_hashed_secret_key_key
+    ON public.api_keys USING btree
+    (fast_hashed_secret_key COLLATE pg_catalog."default" ASC NULLS LAST)
+    TABLESPACE pg_default;
+-- Index: api_keys_hashed_secret_key_idx
+
+-- DROP INDEX IF EXISTS public.api_keys_hashed_secret_key_idx;
+
+CREATE INDEX IF NOT EXISTS api_keys_hashed_secret_key_idx
+    ON public.api_keys USING btree
+    (hashed_secret_key COLLATE pg_catalog."default" ASC NULLS LAST)
+    TABLESPACE pg_default;
+-- Index: api_keys_hashed_secret_key_key
+
+-- DROP INDEX IF EXISTS public.api_keys_hashed_secret_key_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS api_keys_hashed_secret_key_key
+    ON public.api_keys USING btree
+    (hashed_secret_key COLLATE pg_catalog."default" ASC NULLS LAST)
+    TABLESPACE pg_default;
+-- Index: api_keys_id_key
+
+-- DROP INDEX IF EXISTS public.api_keys_id_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS api_keys_id_key
+    ON public.api_keys USING btree
+    (id COLLATE pg_catalog."default" ASC NULLS LAST)
+    TABLESPACE pg_default;
+-- Index: api_keys_project_id_idx
+
+-- DROP INDEX IF EXISTS public.api_keys_project_id_idx;
+
+CREATE INDEX IF NOT EXISTS api_keys_project_id_idx
+    ON public.api_keys USING btree
+    (project_id COLLATE pg_catalog."default" ASC NULLS LAST)
+    TABLESPACE pg_default;
+-- Index: api_keys_public_key_idx
+
+-- DROP INDEX IF EXISTS public.api_keys_public_key_idx;
+
+CREATE INDEX IF NOT EXISTS api_keys_public_key_idx
+    ON public.api_keys USING btree
+    (public_key COLLATE pg_catalog."default" ASC NULLS LAST)
+    TABLESPACE pg_default;
+-- Index: api_keys_public_key_key
+
+-- DROP INDEX IF EXISTS public.api_keys_public_key_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS api_keys_public_key_key
+    ON public.api_keys USING btree
+    (public_key COLLATE pg_catalog."default" ASC NULLS LAST)
+    TABLESPACE pg_default;

--- a/packages/langfarm-io/tests/langfuse/init_db/init_data.sql
+++ b/packages/langfarm-io/tests/langfuse/init_db/init_data.sql
@@ -1,0 +1,41 @@
+-- password is langfarm
+insert into users(id, name, email, password) values (
+	'cm6g082zk000013r2t86dhtib', 'Langfarm', 'langfarm@126.com'
+	, '$2a$12$PwlfT9JPFYcnAzYCXHx1x.AgdlZwyVLeSmFmAPwkWA6VVTAYRnuMW'
+)
+;
+
+insert into organizations(id, name) values ('cm6g0t2nu000113r2msztoha4', 'langfarm');
+
+insert into projects(id, name, org_id) values ('cm6g0uptx000613r2ha6hxtkc', 'llm-demo', 'cm6g0t2nu000113r2msztoha4');
+
+-- LANGFUSE_SECRET_KEY=sk-lf-f69c6951-3462-4997-ba22-1c598e8308aa
+-- LANGFUSE_PUBLIC_KEY=pk-lf-a82c2304-c8ee-4b24-aafc-f3d228ca336c
+insert into api_keys(id, public_key, hashed_secret_key, display_secret_key, project_id, fast_hashed_secret_key) values (
+    'cm6g0uzgj000913r25shr4z98', 'pk-lf-a82c2304-c8ee-4b24-aafc-f3d228ca336c'
+    , '$2a$11$J6Sjn80QIyA0T1uy8V2ei.VqaiMjqH0B6dDz83xwxC0T6Mkw7awSe'
+    , 'sk-lf-...08aa', 'cm6g0uptx000613r2ha6hxtkc'
+    , 'ba74bf29a00183aa793040fc20dc94930e99826c40b0c85ec746688a62f04c47'
+);
+
+INSERT INTO models(
+	id, created_at, updated_at, project_id, model_name, match_pattern
+	, start_date, input_price, output_price, total_price, unit, tokenizer_config, tokenizer_id
+) VALUES
+(
+	'cm3azlpbl000o3rpmuhabmi9y',now(),now(),null,'qwen-turbo','(?i)^(qwen-turbo)(-[\da-zA-Z]+)*$'
+	,null,0.0000003,0.0000006,null,'TOKENS','{}',null
+)
+,(
+	'cm3azj5o6000g3rpmnd4llx6f',now(),now(),null,'qwen-plus','(?i)^(qwen-plus)(-[\da-zA-Z]+)*$'
+	,null,0.0000016,0.000004,null,'TOKENS','{}',null
+)
+,(
+	'cm3azj5o6000g3rpmxb3iiu8g',now(),now(),null,'qwen-plus','(?i)^(qwen-plus)(-[\da-zA-Z]+)*$'
+	,'2024-10-01',0.0000008,0.000002,null,'TOKENS','{}',null
+)
+,(
+	'cm3b047f2000w3rpmdnv0bxpb',now(),now(),null,'qwen-max','(?i)^(qwen-max)(-[\da-zA-Z]+)*$'
+	,null,0.00002,0.00006,null,'TOKENS','{}',null
+)
+;

--- a/packages/langfarm-io/tests/langfuse/init_db/models.sql
+++ b/packages/langfarm-io/tests/langfuse/init_db/models.sql
@@ -1,0 +1,46 @@
+-- Table: public.models
+
+-- DROP TABLE IF EXISTS public.models;
+
+CREATE TABLE IF NOT EXISTS public.models
+(
+    id text COLLATE pg_catalog."default" NOT NULL,
+    created_at timestamp(3) without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp(3) without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    project_id text COLLATE pg_catalog."default",
+    model_name text COLLATE pg_catalog."default" NOT NULL,
+    match_pattern text COLLATE pg_catalog."default" NOT NULL,
+    start_date timestamp(3) without time zone,
+    input_price numeric(65,30),
+    output_price numeric(65,30),
+    total_price numeric(65,30),
+    unit text COLLATE pg_catalog."default",
+    tokenizer_config jsonb,
+    tokenizer_id text COLLATE pg_catalog."default",
+    CONSTRAINT models_pkey PRIMARY KEY (id),
+    CONSTRAINT models_project_id_fkey FOREIGN KEY (project_id)
+        REFERENCES public.projects (id) MATCH SIMPLE
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS public.models
+    OWNER to test;
+-- Index: models_model_name_idx
+
+-- DROP INDEX IF EXISTS public.models_model_name_idx;
+
+CREATE INDEX IF NOT EXISTS models_model_name_idx
+    ON public.models USING btree
+    (model_name COLLATE pg_catalog."default" ASC NULLS LAST)
+    TABLESPACE pg_default;
+-- Index: models_project_id_model_name_start_date_unit_key
+
+-- DROP INDEX IF EXISTS public.models_project_id_model_name_start_date_unit_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS models_project_id_model_name_start_date_unit_key
+    ON public.models USING btree
+    (project_id COLLATE pg_catalog."default" ASC NULLS LAST, model_name COLLATE pg_catalog."default" ASC NULLS LAST, start_date ASC NULLS LAST, unit COLLATE pg_catalog."default" ASC NULLS LAST)
+    TABLESPACE pg_default;

--- a/packages/langfarm-io/tests/langfuse/init_db/organizations.sql
+++ b/packages/langfarm-io/tests/langfuse/init_db/organizations.sql
@@ -1,0 +1,18 @@
+-- Table: public.organizations
+
+-- DROP TABLE IF EXISTS public.organizations;
+
+CREATE TABLE IF NOT EXISTS public.organizations
+(
+    id text COLLATE pg_catalog."default" NOT NULL,
+    name text COLLATE pg_catalog."default" NOT NULL,
+    created_at timestamp(3) without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp(3) without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    cloud_config jsonb,
+    CONSTRAINT organizations_pkey PRIMARY KEY (id)
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS public.organizations
+    OWNER to test;

--- a/packages/langfarm-io/tests/langfuse/init_db/projects.sql
+++ b/packages/langfarm-io/tests/langfuse/init_db/projects.sql
@@ -1,0 +1,30 @@
+-- Table: public.projects
+
+-- DROP TABLE IF EXISTS public.projects;
+
+CREATE TABLE IF NOT EXISTS public.projects
+(
+    id text COLLATE pg_catalog."default" NOT NULL,
+    created_at timestamp(3) without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    name text COLLATE pg_catalog."default" NOT NULL,
+    updated_at timestamp(3) without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    org_id text COLLATE pg_catalog."default" NOT NULL,
+    CONSTRAINT projects_pkey PRIMARY KEY (id),
+    CONSTRAINT projects_org_id_fkey FOREIGN KEY (org_id)
+        REFERENCES public.organizations (id) MATCH SIMPLE
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS public.projects
+    OWNER to test;
+-- Index: projects_org_id_idx
+
+-- DROP INDEX IF EXISTS public.projects_org_id_idx;
+
+CREATE INDEX IF NOT EXISTS projects_org_id_idx
+    ON public.projects USING btree
+    (org_id COLLATE pg_catalog."default" ASC NULLS LAST)
+    TABLESPACE pg_default;

--- a/packages/langfarm-io/tests/langfuse/init_db/users.sql
+++ b/packages/langfarm-io/tests/langfuse/init_db/users.sql
@@ -1,0 +1,31 @@
+-- Table: public.users
+
+-- DROP TABLE IF EXISTS public.users;
+
+CREATE TABLE IF NOT EXISTS public.users
+(
+    id text COLLATE pg_catalog."default" NOT NULL,
+    name text COLLATE pg_catalog."default",
+    email text COLLATE pg_catalog."default",
+    email_verified timestamp(3) without time zone,
+    password text COLLATE pg_catalog."default",
+    image text COLLATE pg_catalog."default",
+    created_at timestamp(3) without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp(3) without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    feature_flags text[] COLLATE pg_catalog."default" DEFAULT ARRAY[]::text[],
+    admin boolean NOT NULL DEFAULT false,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS public.users
+    OWNER to test;
+-- Index: users_email_key
+
+-- DROP INDEX IF EXISTS public.users_email_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS users_email_key
+    ON public.users USING btree
+    (email COLLATE pg_catalog."default" ASC NULLS LAST)
+    TABLESPACE pg_default;

--- a/packages/langfarm-io/tests/langfuse/test_auth_key.py
+++ b/packages/langfarm-io/tests/langfuse/test_auth_key.py
@@ -1,0 +1,44 @@
+import unittest
+
+from langfarm_io.langfuse import auth
+from env_config import LangfuseEnv
+
+
+class MyTestCase(unittest.TestCase):
+    def test_decode_from_basic_auth(self):
+        my_pk = "this_is_pk"
+        my_sk = "this_is_sk"
+        authorization = "Basic dGhpc19pc19wazp0aGlzX2lzX3Nr"
+        pk, sk = auth.decode_from_basic_auth(authorization)
+        assert pk
+        assert pk == my_pk
+
+        assert sk
+        assert sk == my_sk
+
+        # is only pk
+        authorization = "Basic dGhpc19pc19waw=="
+        pk, sk = auth.decode_from_basic_auth(authorization)
+        assert pk
+        assert pk == my_pk
+
+        assert sk is None
+
+        # is pk, sk is blank
+        authorization = "Basic dGhpc19pc19wazo="
+        pk, sk = auth.decode_from_basic_auth(authorization)
+        assert pk
+        assert pk == my_pk
+
+        assert sk == ""
+
+    def test_fast_hashed_secret_key(self):
+        langfuse_env = LangfuseEnv()
+        # langfuse 系统生成的 fast_hashed_secret_key
+        fast_hashed_secret_key = "ba74bf29a00183aa793040fc20dc94930e99826c40b0c85ec746688a62f04c47"
+        gen_fast_hashed_key = auth.fast_hashed_secret_key(langfuse_env.LANGFUSE_SECRET_KEY, langfuse_env.SALT)
+        assert gen_fast_hashed_key == fast_hashed_secret_key
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/langfarm-io/tests/langfuse/test_crud.py
+++ b/packages/langfarm-io/tests/langfuse/test_crud.py
@@ -1,0 +1,163 @@
+import unittest
+from decimal import Decimal
+
+import sqlalchemy
+
+from langfarm_io.langfuse import crud
+from langfarm_io.langfuse.crud import get_api_key_by_cache, find_model, find_model_by_cache
+from langfarm_io.langfuse.local_cache import get_cache_info
+from langfarm_tests.base_container import BasePostgresContainerTestCase
+from langfarm_tests.base_for_test import get_test_logger
+
+from sqlalchemy import select
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.schema import CreateTable
+
+from langfarm_io.langfuse import auth, db_reader
+from langfarm_io.langfuse.schema import ApiKey
+from env_config import LangfuseEnv
+
+logger = get_test_logger(__name__)
+
+
+class UseLangfuseDBTestCase(BasePostgresContainerTestCase):
+    @classmethod
+    def _set_up_class_other(cls):
+        super()._set_up_class_other()
+        db_reader.engine = cls.db_engine
+        # init langfuse db
+        # load sql file
+        base_dir = __file__[: -len(f"/{__name__}.py")]
+        sql_file_names = [
+            "users.sql",
+            "organizations.sql",
+            "projects.sql",
+            "api_keys.sql",
+            "models.sql",
+            "init_data.sql",
+        ]
+        sql_file_paths = []
+        sql_texts: list[str] = []
+        for sql_file in sql_file_names:
+            sql_file_path = f"{base_dir}/init_db/{sql_file}"
+            sql_file_paths.append(sql_file_path)
+            with open(sql_file_path, "r") as file:
+                sql_texts.append(file.read())
+
+        # execute sql for init
+        with cls.db_engine.begin() as conn:
+            for idx in range(len(sql_file_paths)):
+                logger.info("import sql in file=[%s]", sql_file_paths[idx])
+                result = conn.execute(sqlalchemy.text(sql_texts[idx]))
+                logger.info("db exc result:%s", repr(result))
+
+    def test_show_create_api_key_sql(self):
+        ct = CreateTable(ApiKey.__table__)  # pyright: ignore
+        sql = ct.compile(dialect=postgresql.dialect())
+        logger.info("sql=%s", sql)
+        assert str(sql).find("WITHOUT TIME ZONE") > 0
+
+    def test_postgresql_connection(self):
+        with self.db_engine.connect() as conn:
+            result = conn.execute(sqlalchemy.text("select version()"))
+            if result:
+                row = result.fetchone()
+                if row:
+                    logger.info("version=%s", row[0])
+
+    def assert_api_key(self, api_key: ApiKey, env: LangfuseEnv):
+        assert env
+        assert api_key
+
+        logger.info("id = %s", api_key.id)
+        logger.info("pk = %s", api_key.public_key)
+        logger.info("created_at = %s", api_key.created_at.strftime("%Y-%m-%d %H:%M:%S"))
+        assert api_key.public_key == env.LANGFUSE_PUBLIC_KEY
+        assert api_key.fast_hashed_secret_key
+
+        sk = env.LANGFUSE_SECRET_KEY
+        salt = env.SALT
+        fast_hashed = auth.fast_hashed_secret_key(sk, salt)
+
+        assert api_key.fast_hashed_secret_key == fast_hashed
+
+    def test_select_api_key_by_pk_sk(self):
+        env = LangfuseEnv()
+
+        # read first
+        stmt = select(ApiKey).where(ApiKey.public_key == env.LANGFUSE_PUBLIC_KEY)
+
+        api_key = db_reader.read_first(stmt, ApiKey)
+        assert api_key
+        self.assert_api_key(api_key, env)
+
+        # select_api_key_by_pk_sk
+        api_key = crud.select_api_key_by_pk_sk(env.LANGFUSE_PUBLIC_KEY, env.LANGFUSE_SECRET_KEY, env.SALT)
+        assert api_key
+        self.assert_api_key(api_key, env)
+
+    def test_get_api_key_by_cache(self):
+        env = LangfuseEnv()
+        cache_info = get_cache_info(get_api_key_by_cache)
+        assert cache_info
+        assert cache_info.currsize == 0
+        assert cache_info.hits == 0
+        api_key = get_api_key_by_cache(env.LANGFUSE_PUBLIC_KEY, env.LANGFUSE_SECRET_KEY, env.SALT)
+        assert api_key
+        self.assert_api_key(api_key, env)
+        cache_info = get_cache_info(get_api_key_by_cache)
+        assert cache_info.currsize == 1
+        assert cache_info.hits == 0
+
+        new_api_key = get_api_key_by_cache(env.LANGFUSE_PUBLIC_KEY, env.LANGFUSE_SECRET_KEY, env.SALT)
+        assert new_api_key
+        assert new_api_key == api_key
+        cache_info = get_cache_info(get_api_key_by_cache)
+        assert cache_info.currsize == 1
+        assert cache_info.hits == 1
+
+    def test_find_model(self):
+        env = LangfuseEnv()
+        model_name = "qwen-plus"
+        model = find_model(model_name, env.PROJECT_ID)
+        assert model
+        assert model.model_name == model_name
+        assert model.input_price == Decimal("0.0000008")
+        assert model.output_price == Decimal("0.000002")
+
+        model_name = "qwen-max"
+        model = find_model(model_name, env.PROJECT_ID)
+        assert model
+        assert model.model_name == model_name
+        assert model.input_price == Decimal("0.00002")
+        assert model.output_price == Decimal("0.00006")
+
+    def test_find_model_by_cache(self):
+        env = LangfuseEnv()
+        cache_info = get_cache_info(find_model_by_cache)
+        assert cache_info
+        assert cache_info.currsize == 0
+        assert cache_info.hits == 0
+
+        model_name = "qwen-plus"
+        model = find_model_by_cache(model_name, env.PROJECT_ID)
+        assert model
+        assert model.model_name == model_name
+        assert model.input_price == Decimal("0.0000008")
+        assert model.output_price == Decimal("0.000002")
+        cache_info = get_cache_info(find_model_by_cache)
+        assert cache_info.currsize == 1
+        assert cache_info.hits == 0
+
+        model = find_model_by_cache(model_name, env.PROJECT_ID)
+        assert model
+        assert model.model_name == model_name
+        assert model.input_price == Decimal("0.0000008")
+        assert model.output_price == Decimal("0.000002")
+        cache_info = get_cache_info(find_model_by_cache)
+        assert cache_info.currsize == 1
+        assert cache_info.hits == 1
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/langfarm-tests/src/langfarm_tests/base_container.py
+++ b/packages/langfarm-tests/src/langfarm_tests/base_container.py
@@ -3,7 +3,7 @@ from abc import abstractmethod
 from typing import final
 
 import sqlalchemy
-from sqlalchemy.engine.base import Connection, Engine
+from sqlalchemy.engine.base import Engine
 from testcontainers.core.container import DockerContainer
 from testcontainers.postgres import PostgresContainer
 
@@ -62,12 +62,3 @@ class BasePostgresContainerTestCase(BaseContainerTestCase):
         postgres_container = PostgresContainer("postgres:latest", driver="psycopg")
         cls.postgres_container = postgres_container
         return postgres_container
-
-    def setUp(self):
-        self.connection: Connection = self.db_engine.connect()
-        logger.info("Connected to postgres [%s]", self.postgres_container.get_connection_url())
-
-    def tearDown(self):
-        if self.connection:
-            self.connection.close()
-            logger.info("Disconnected from postgres [%s]", self.postgres_container.get_connection_url())

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,17 @@ requires-python = ">=3.11"
 [manifest]
 members = [
     "langfarm",
+    "langfarm-io",
     "langfarm-tests",
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "http://mirrors.aliyun.com/pypi/simple/" }
+sdist = { url = "http://mirrors.aliyun.com/pypi/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89" }
+wheels = [
+    { url = "http://mirrors.aliyun.com/pypi/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53" },
 ]
 
 [[package]]
@@ -30,6 +40,15 @@ dependencies = [
 sdist = { url = "http://mirrors.aliyun.com/pypi/packages/a7/fe/7ebfec74d49f97fc55cd38240c7a7d08134002b1e14be8c3897c0dd5e49b/binaryornot-0.4.4.tar.gz", hash = "sha256:359501dfc9d40632edc9fac890e19542db1a287bbcfa58175b66658392018061" }
 wheels = [
     { url = "http://mirrors.aliyun.com/pypi/packages/24/7e/f7b6f453e6481d1e233540262ccbfcf89adcd43606f44a028d7f5fae5eb2/binaryornot-0.4.4-py2.py3-none-any.whl", hash = "sha256:b8b71173c917bddcd2c16070412e369c3ed7f0528926f70cac18a6c97fd563e4" },
+]
+
+[[package]]
+name = "cachetools"
+version = "5.5.1"
+source = { registry = "http://mirrors.aliyun.com/pypi/simple/" }
+sdist = { url = "http://mirrors.aliyun.com/pypi/packages/d9/74/57df1ab0ce6bc5f6fa868e08de20df8ac58f9c44330c7671ad922d2bbeae/cachetools-5.5.1.tar.gz", hash = "sha256:70f238fbba50383ef62e55c6aff6d9673175fe59f7c6782c7a0b9e38f4a9df95" }
+wheels = [
+    { url = "http://mirrors.aliyun.com/pypi/packages/ec/4e/de4ff18bcf55857ba18d3a4bd48c8a9fde6bb0980c9d20b263f05387fd88/cachetools-5.5.1-py3-none-any.whl", hash = "sha256:b76651fdc3b24ead3c648bbdeeb940c1b04d365b38b4af66788f9ec4a81d42bb" },
 ]
 
 [[package]]
@@ -254,6 +273,28 @@ dev = [
 ]
 
 [[package]]
+name = "langfarm-io"
+version = "0.1.0"
+source = { editable = "packages/langfarm-io" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "psycopg", extra = ["binary"] },
+    { name = "pydantic" },
+    { name = "sqlalchemy" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "cachetools", specifier = ">=5.5.1" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2.4" },
+    { name = "pydantic", specifier = ">=2.10.6" },
+    { name = "sqlalchemy", specifier = ">=2.0.37" },
+]
+
+[package.metadata.requires-dev]
+dev = []
+
+[[package]]
 name = "langfarm-tests"
 version = "0.1.0"
 source = { editable = "packages/langfarm-tests" }
@@ -388,6 +429,131 @@ dependencies = [
 sdist = { url = "http://mirrors.aliyun.com/pypi/packages/d1/10/11f929bad564b2dbc5c119ecf0f37456ac24538bb4a70c76f140a2aa695a/poethepoet-0.32.1.tar.gz", hash = "sha256:471e1a025812dcd3d2997e30989681be5ab0a49232ee5fba94859629671c9584" }
 wheels = [
     { url = "http://mirrors.aliyun.com/pypi/packages/85/a5/fc26dd508f33809bdd3823a0170e492fe44ad7e097c32c4a52e16cf3ecb0/poethepoet-0.32.1-py3-none-any.whl", hash = "sha256:d1e0a52a2f677870fac17dfb26bfe4910242756ac821443ef31f90ad26227c2d" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.2.4"
+source = { registry = "http://mirrors.aliyun.com/pypi/simple/" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "http://mirrors.aliyun.com/pypi/packages/e0/f2/954b1467b3e2ca5945b83b5e320268be1f4df486c3e8ffc90f4e4b707979/psycopg-3.2.4.tar.gz", hash = "sha256:f26f1346d6bf1ef5f5ef1714dd405c67fb365cfd1c6cea07de1792747b167b92" }
+wheels = [
+    { url = "http://mirrors.aliyun.com/pypi/packages/40/49/15114d5f7ee68983f4e1a24d47e75334568960352a07c6f0e796e912685d/psycopg-3.2.4-py3-none-any.whl", hash = "sha256:43665368ccd48180744cab26b74332f46b63b7e06e8ce0775547a3533883d381" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.2.4"
+source = { registry = "http://mirrors.aliyun.com/pypi/simple/" }
+wheels = [
+    { url = "http://mirrors.aliyun.com/pypi/packages/f3/9a/8013aa4ad4d76dfcf9b822da549d51aab96abfc77afc44b200ef295685dc/psycopg_binary-3.2.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d092b0aa80b8c3ee0701a7252cbfb0bdb742e1f74aaf0c1a13ef22c05c9266ab" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/1e/65/2422036d0169e33e5f06d868a36235340f85e42afe153d59b0edf4b4210f/psycopg_binary-3.2.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3955381dacc6d15f3838d5f25445ee99f80882876a163f8de0c01ffc54aeef4a" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/bf/ab/4f6c815862d62d9d06353abfbf36fef69ad7e6ca0763eed1629f47579e83/psycopg_binary-3.2.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:04144d1963aa3309247980f1a742b98e15f60d68ea9745143c433f99aaeb70d7" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/27/ef/0e5e9ea6122f61f9e0c4e70b7f7a28ef51404c98bbb32096ad99f79f85b5/psycopg_binary-3.2.4-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eac61931bc90c1c6fdc648452894d3a434a005ffefaf12819b4709548c894bf2" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/93/cd/05d71e4f2f7f69fd185d2ec44b66de13734ff70c426ead14523e206258bb/psycopg_binary-3.2.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c09b765960480c4586758a3c16f0ee0db6f7e2f31c88cccb5e7d7024215468cd" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/af/7c/f5099ad491f78ba491e56cd686b38b0737eb09a719e919661a9f8d08e754/psycopg_binary-3.2.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:220de8efcc276e42ba7cc7ed613145b1274b6b5de321a1396fb6b6ce1758d34c" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/2d/95/a1a2f861d90f3394f98d032329a1e44a67c8d1f5bded0ec343b664c65ba5/psycopg_binary-3.2.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b558d3de315d18819ce477908e27518cbdd3275717c6193b58dde36f0443e167" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/ab/72/0b395ad2db2adc6009d2a1cdc2707b1764a3e870d6895cf92dc87e251aa9/psycopg_binary-3.2.4-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e3b4c9b9a112d43533f7dbdedbb1188107d4ddcd262e2a2af41b4de0caf7d053" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/ba/5d/8e9904664e5bae3852989a0f1b0517c781ff0a9cba64416ffa68952129ac/psycopg_binary-3.2.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:870df866f789bb641a350897c1751c293b9420f46be4eb366d190ff5f2f2ffd8" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/46/6a/9abc03e01c1cb97878e6e87d5ea9e3d925790b04fa03d72b2d6e3455f124/psycopg_binary-3.2.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:89506e268fb95428fb0f8f7abe48032e66cf47390469e11a4fe989f7407a5d88" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/12/c5/1be474bfa7282aa9177c3e498eb641b1441724f0155953f3872c69deddf0/psycopg_binary-3.2.4-cp311-cp311-win_amd64.whl", hash = "sha256:7ddf1494cc3bf60761c01265c44dfc7a7fd63f21308c403c14f5dd91702df84d" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/48/f8/f30cf36bc9bc672894413f10f0498d5e81b0813c87f1b963d85e7c5cc9f1/psycopg_binary-3.2.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3ac24b3d421127ebe8662eba2c1e149a12f0f5b6795e66c1811a3f59111456bb" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/2f/23/88a265ca4a35def6f53cb239e352bf52f01ea418f57f4272b3913ecd6fd2/psycopg_binary-3.2.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f702f36204127984dd212eb57bb328676abdfe8a56f179e408a806d5e520aa11" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/0f/2b/2ac3456208c255a6fad9fec4fea0e411e34a0b4b0ecd1e60c0ba36fb78c4/psycopg_binary-3.2.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:610cd2013ee0849154fcff34b0cca17f720c91c7430ca094a61f1e5ff1d38e15" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/55/f5/725b786b7cf1b91f1afbe03545f0b14857c0a5cc03b4f8a6735ec289ff89/psycopg_binary-3.2.4-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:95da59edd95f6b6488799c9710fafc2d5750e3ec6328ec991f7a9be04efe6886" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/09/80/72b3a1ec912b8be51e6af858fcd2a016d25145aca400e75bba6ab91025c4/psycopg_binary-3.2.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b71e98e3186f08473962e1ea4bfbc4387ecc398644b794cb112ad0a4276e3789" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/0b/8e/6cd6643f04e033bcdab008d5175c9356ade1eecff53fa4558d383dd9866c/psycopg_binary-3.2.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ccf4f71c3a0d46bc74207bf7997f010a6586414161dd10f3dd026ec059942ef" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/85/47/50d93bef98d32eba1f7b95e3c4e671a7f59b1d0b9ed01fdb43e951d6012b/psycopg_binary-3.2.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:244e1dd33b694792b7bc7a3d412a535ba39116218b07d8936b4591567f4121e9" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/2e/a0/2cf0dda5634d14219a24c05bc85cb928a5b2ea29684d167aebc974df016c/psycopg_binary-3.2.4-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:f8dc8f4de5130c6278dd5e34b18ad8324a74658a7adb72d4e67ca97f9aeaaf3c" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/14/65/13b3dd91dd62f6e4ee3cb00bd24ab60a251592c03a8fb090c28057f21e38/psycopg_binary-3.2.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c336e58a48061a9189d3ba8c19f00fe5d9570219e6f7f954b923ad5c33e5bc71" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/07/cc/90b5307ff833892c8985aefd73c1894b1a9d8b5df4965650e95636ba8161/psycopg_binary-3.2.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9633c5dc6796d11766d2475e62335b67e5f99f119f40ba1675c1d23208d7709d" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/40/dc/5ab8fec2fc2e0599fd7a60abe046c853477bbb7cd978b818f795c5423848/psycopg_binary-3.2.4-cp312-cp312-win_amd64.whl", hash = "sha256:295c25e56b430d786a475c5c2cef266b0b27c0a6fcaadf9d83a4cdcfb76f971f" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/25/e2/f56675aada063762f08559b6969e47e1313f269fc1682c16457c13da8186/psycopg_binary-3.2.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:81ab801c0d35830c876bf0d1edc8e7dd2f73aa2b04fe24eb812159c0b054d149" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/7b/8b/8c4a66b2b3db494367df0299535b7d2df78f303334228c517b8d00c411d5/psycopg_binary-3.2.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c09e02ce1124eb6638b3381df050a8cf88aedfad4522f939945cda49050a990c" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/84/e8/618d45f77cebce73d75497c95685a0902aea3783386d9335ce486c69e13a/psycopg_binary-3.2.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a249cdc6a5c2b5088a8677acba66b291e5237524739ab3d27498e1ef189312f5" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/c4/87/fc30318e6b97e723e017e7dc88d0f721bbfb749de1a6e414e52d4ac54c9a/psycopg_binary-3.2.4-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d2960ba8a5c0ad75e184f6d8bf76bdf023708999efe75fe4e13445136c1cd206" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/91/30/1d127e651c21cd77befaf361c7c3b9001bfff51ac38027e8fce598ba0701/psycopg_binary-3.2.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3dae2e50b0d3425c167eebbedc3553f7c811dbc0dbfc737b6877f68a03be7daf" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/0d/5e/22c824cb38745c1c744cec85d227190727c564afb75960ce0057ca15fd84/psycopg_binary-3.2.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:03bf7ee7e0002c2cce43ecb923ec510358056eb2e44a96afaeb0424518f35206" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/b3/83/ae8783dec3f7e39df8a4056e4d383926ffec531970c0b415d48d9fd4a2c2/psycopg_binary-3.2.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5f5c85eeb63b1a8a6b026eef57f5da36ff215ce9a6a3bb8e20a409670d6cfbda" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/be/f7/fb7bffb0c4c45a5a82fe324e4f7b176075a4c5372e546a038858dd13c7ab/psycopg_binary-3.2.4-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8c7b95899d4d6d23c5cc46cb3419e8e6ca68d867509432ee1487042564a1ea55" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/81/a3/29f4993a239d6a3fb18ef8681d9990c007f5f73bdd2e21f65f07ac55ad6f/psycopg_binary-3.2.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:fa4acea9ca20a567c3872a5afab2084751530bb57b8fb6b52820d5c54e7c8c3b" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/25/5b/925171cbfa2e3d1ccb7f4c005d0d5db609ba796c1d08a23c42825b09c554/psycopg_binary-3.2.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c487f35a1905bb15da927c1fc05f70f3d29f0e21fb4ba21d360a0da9c755f20" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/b6/47/25b2b85b8fcabf99bfa92b4b0d587894c01576bf0b2bf137c243d1eb1070/psycopg_binary-3.2.4-cp313-cp313-win_amd64.whl", hash = "sha256:80297c3a9f7b5a6afdb0d8f220661ccd796e5c9128c44b32c41267f7daefd37f" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.10.6"
+source = { registry = "http://mirrors.aliyun.com/pypi/simple/" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "http://mirrors.aliyun.com/pypi/packages/b7/ae/d5220c5c52b158b1de7ca89fc5edb72f304a70a4c540c84c8844bf4008de/pydantic-2.10.6.tar.gz", hash = "sha256:ca5daa827cce33de7a42be142548b0096bf05a7e7b365aebfa5f8eeec7128236" }
+wheels = [
+    { url = "http://mirrors.aliyun.com/pypi/packages/f4/3c/8cc1cc84deffa6e25d2d0c688ebb80635dfdbf1dbea3e30c541c8cf4d860/pydantic-2.10.6-py3-none-any.whl", hash = "sha256:427d664bf0b8a2b34ff5dd0f5a18df00591adcee7198fbd71981054cef37b584" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.27.2"
+source = { registry = "http://mirrors.aliyun.com/pypi/simple/" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "http://mirrors.aliyun.com/pypi/packages/fc/01/f3e5ac5e7c25833db5eb555f7b7ab24cd6f8c322d3a3ad2d67a952dc0abc/pydantic_core-2.27.2.tar.gz", hash = "sha256:eb026e5a4c1fee05726072337ff51d1efb6f59090b7da90d30ea58625b1ffb39" }
+wheels = [
+    { url = "http://mirrors.aliyun.com/pypi/packages/c2/89/f3450af9d09d44eea1f2c369f49e8f181d742f28220f88cc4dfaae91ea6e/pydantic_core-2.27.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:8e10c99ef58cfdf2a66fc15d66b16c4a04f62bca39db589ae8cba08bc55331bc" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/9e/e3/71fe85af2021f3f386da42d291412e5baf6ce7716bd7101ea49c810eda90/pydantic_core-2.27.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:26f32e0adf166a84d0cb63be85c562ca8a6fa8de28e5f0d92250c6b7e9e2aff7" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/a6/3c/724039e0d848fd69dbf5806894e26479577316c6f0f112bacaf67aa889ac/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c19d1ea0673cd13cc2f872f6c9ab42acc4e4f492a7ca9d3795ce2b112dd7e15" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/2b/5b/1b29e8c1fb5f3199a9a57c1452004ff39f494bbe9bdbe9a81e18172e40d3/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5e68c4446fe0810e959cdff46ab0a41ce2f2c86d227d96dc3847af0ba7def306" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/89/6c/3985203863d76bb7d7266e36970d7e3b6385148c18a68cc8915fd8c84d57/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d9640b0059ff4f14d1f37321b94061c6db164fbe49b334b31643e0528d100d99" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/0e/41/f15316858a246b5d723f7d7f599f79e37493b2e84bfc789e58d88c209f8a/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40d02e7d45c9f8af700f3452f329ead92da4c5f4317ca9b896de7ce7199ea459" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/a8/7c/b860618c25678bbd6d1d99dbdfdf0510ccb50790099b963ff78a124b754f/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c1fd185014191700554795c99b347d64f2bb637966c4cfc16998a0ca700d048" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/bf/73/42c3742a391eccbeab39f15213ecda3104ae8682ba3c0c28069fbcb8c10d/pydantic_core-2.27.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d81d2068e1c1228a565af076598f9e7451712700b673de8f502f0334f281387d" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/94/7a/941e89096d1175d56f59340f3a8ebaf20762fef222c298ea96d36a6328c5/pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1a4207639fb02ec2dbb76227d7c751a20b1a6b4bc52850568e52260cae64ca3b" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/6e/95/2359937a73d49e336a5a19848713555605d4d8d6940c3ec6c6c0ca4dcf25/pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:3de3ce3c9ddc8bbd88f6e0e304dea0e66d843ec9de1b0042b0911c1663ffd474" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/2b/4c/ca02b7bdb6012a1adef21a50625b14f43ed4d11f1fc237f9d7490aa5078c/pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:30c5f68ded0c36466acede341551106821043e9afaad516adfb6e8fa80a4e6a6" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/72/9d/a241db83f973049a1092a079272ffe2e3e82e98561ef6214ab53fe53b1c7/pydantic_core-2.27.2-cp311-cp311-win32.whl", hash = "sha256:c70c26d2c99f78b125a3459f8afe1aed4d9687c24fd677c6a4436bc042e50d6c" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/e8/ef/013f07248041b74abd48a385e2110aa3a9bbfef0fbd97d4e6d07d2f5b89a/pydantic_core-2.27.2-cp311-cp311-win_amd64.whl", hash = "sha256:08e125dbdc505fa69ca7d9c499639ab6407cfa909214d500897d02afb816e7cc" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/10/1c/16b3a3e3398fd29dca77cea0a1d998d6bde3902fa2706985191e2313cc76/pydantic_core-2.27.2-cp311-cp311-win_arm64.whl", hash = "sha256:26f0d68d4b235a2bae0c3fc585c585b4ecc51382db0e3ba402a22cbc440915e4" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/d6/74/51c8a5482ca447871c93e142d9d4a92ead74de6c8dc5e66733e22c9bba89/pydantic_core-2.27.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:9e0c8cfefa0ef83b4da9588448b6d8d2a2bf1a53c3f1ae5fca39eb3061e2f0b0" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/d3/f3/c97e80721735868313c58b89d2de85fa80fe8dfeeed84dc51598b92a135e/pydantic_core-2.27.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:83097677b8e3bd7eaa6775720ec8e0405f1575015a463285a92bfdfe254529ef" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/9e/91/840ec1375e686dbae1bd80a9e46c26a1e0083e1186abc610efa3d9a36180/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:172fce187655fece0c90d90a678424b013f8fbb0ca8b036ac266749c09438cb7" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/f6/31/4240bc96025035500c18adc149aa6ffdf1a0062a4b525c932065ceb4d868/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:519f29f5213271eeeeb3093f662ba2fd512b91c5f188f3bb7b27bc5973816934" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/fa/20/02fbaadb7808be578317015c462655c317a77a7c8f0ef274bc016a784c54/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:05e3a55d124407fffba0dd6b0c0cd056d10e983ceb4e5dbd10dda135c31071d6" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/06/86/7f306b904e6c9eccf0668248b3f272090e49c275bc488a7b88b0823444a4/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9c3ed807c7b91de05e63930188f19e921d1fe90de6b4f5cd43ee7fcc3525cb8c" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/8d/f0/49129b27c43396581a635d8710dae54a791b17dfc50c70164866bbf865e3/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6fb4aadc0b9a0c063206846d603b92030eb6f03069151a625667f982887153e2" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/0d/0f/943b4af7cd416c477fd40b187036c4f89b416a33d3cc0ab7b82708a667aa/pydantic_core-2.27.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28ccb213807e037460326424ceb8b5245acb88f32f3d2777427476e1b32c48c4" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/35/40/aea70b5b1a63911c53a4c8117c0a828d6790483f858041f47bab0b779f44/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:de3cd1899e2c279b140adde9357c4495ed9d47131b4a4eaff9052f23398076b3" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/f2/b3/807b94fd337d58effc5498fd1a7a4d9d59af4133e83e32ae39a96fddec9d/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:220f892729375e2d736b97d0e51466252ad84c51857d4d15f5e9692f9ef12be4" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/fc/df/791c827cd4ee6efd59248dca9369fb35e80a9484462c33c6649a8d02b565/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a0fcd29cd6b4e74fe8ddd2c90330fd8edf2e30cb52acda47f06dd615ae72da57" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/9b/67/4e197c300976af185b7cef4c02203e175fb127e414125916bf1128b639a9/pydantic_core-2.27.2-cp312-cp312-win32.whl", hash = "sha256:1e2cb691ed9834cd6a8be61228471d0a503731abfb42f82458ff27be7b2186fc" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/1f/ea/cd7209a889163b8dcca139fe32b9687dd05249161a3edda62860430457a5/pydantic_core-2.27.2-cp312-cp312-win_amd64.whl", hash = "sha256:cc3f1a99a4f4f9dd1de4fe0312c114e740b5ddead65bb4102884b384c15d8bc9" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/bc/49/c54baab2f4658c26ac633d798dab66b4c3a9bbf47cff5284e9c182f4137a/pydantic_core-2.27.2-cp312-cp312-win_arm64.whl", hash = "sha256:3911ac9284cd8a1792d3cb26a2da18f3ca26c6908cc434a18f730dc0db7bfa3b" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/41/b1/9bc383f48f8002f99104e3acff6cba1231b29ef76cfa45d1506a5cad1f84/pydantic_core-2.27.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7d14bd329640e63852364c306f4d23eb744e0f8193148d4044dd3dacdaacbd8b" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/10/6c/e62b8657b834f3eb2961b49ec8e301eb99946245e70bf42c8817350cbefc/pydantic_core-2.27.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:82f91663004eb8ed30ff478d77c4d1179b3563df6cdb15c0817cd1cdaf34d154" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/ba/15/52cfe49c8c986e081b863b102d6b859d9defc63446b642ccbbb3742bf371/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71b24c7d61131bb83df10cc7e687433609963a944ccf45190cfc21e0887b08c9" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/b1/1c/b6f402cfc18ec0024120602bdbcebc7bdd5b856528c013bd4d13865ca473/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fa8e459d4954f608fa26116118bb67f56b93b209c39b008277ace29937453dc9" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/bd/7b/8cb75b66ac37bc2975a3b7de99f3c6f355fcc4d89820b61dffa8f1e81677/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce8918cbebc8da707ba805b7fd0b382816858728ae7fe19a942080c24e5b7cd1" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/c8/f1/786d8fe78970a06f61df22cba58e365ce304bf9b9f46cc71c8c424e0c334/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3f5c2a021bbc5d976107bb302e0131351c2ba54343f8a496dc8783d3d3a6a" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/a6/74/d12b2cd841d8724dc8ffb13fc5cef86566a53ed358103150209ecd5d1999/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd8086fa684c4775c27f03f062cbb9eaa6e17f064307e86b21b9e0abc9c0f02e" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/a0/6e/940bcd631bc4d9a06c9539b51f070b66e8f370ed0933f392db6ff350d873/pydantic_core-2.27.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8d9b3388db186ba0c099a6d20f0604a44eabdeef1777ddd94786cdae158729e4" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/50/cc/a46b34f1708d82498c227d5d80ce615b2dd502ddcfd8376fc14a36655af1/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7a66efda2387de898c8f38c0cf7f14fca0b51a8ef0b24bfea5849f1b3c95af27" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/ca/2d/c365cfa930ed23bc58c41463bae347d1005537dc8db79e998af8ba28d35e/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:18a101c168e4e092ab40dbc2503bdc0f62010e95d292b27827871dc85450d7ee" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/f4/d7/eb64d015c350b7cdb371145b54d96c919d4db516817f31cd1c650cae3b21/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ba5dd002f88b78a4215ed2f8ddbdf85e8513382820ba15ad5ad8955ce0ca19a1" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/a4/99/bddde3ddde76c03b65dfd5a66ab436c4e58ffc42927d4ff1198ffbf96f5f/pydantic_core-2.27.2-cp313-cp313-win32.whl", hash = "sha256:1ebaf1d0481914d004a573394f4be3a7616334be70261007e47c2a6fe7e50130" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/71/47/82b5e846e01b26ac6f1893d3c5f9f3a2eb6ba79be26eef0b759b4fe72946/pydantic_core-2.27.2-cp313-cp313-win_amd64.whl", hash = "sha256:953101387ecf2f5652883208769a79e48db18c6df442568a0b5ccd8c2723abee" },
+    { url = "http://mirrors.aliyun.com/pypi/packages/51/b2/b2b50d5ecf21acf870190ae5d093602d95f66c9c31f9d5de6062eb329ad1/pydantic_core-2.27.2-cp313-cp313-win_arm64.whl", hash = "sha256:ac4dbfd1691affb8f48c2c13241a2e3b60ff23247cbcf981759c768b6633cf8b" },
 ]
 
 [[package]]
@@ -651,6 +817,15 @@ source = { registry = "http://mirrors.aliyun.com/pypi/simple/" }
 sdist = { url = "http://mirrors.aliyun.com/pypi/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8" }
 wheels = [
     { url = "http://mirrors.aliyun.com/pypi/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.1"
+source = { registry = "http://mirrors.aliyun.com/pypi/simple/" }
+sdist = { url = "http://mirrors.aliyun.com/pypi/packages/43/0f/fa4723f22942480be4ca9527bbde8d43f6c3f2fe8412f00e7f5f6746bc8b/tzdata-2025.1.tar.gz", hash = "sha256:24894909e88cdb28bd1636c6887801df64cb485bd593f2fd83ef29075a81d694" }
+wheels = [
+    { url = "http://mirrors.aliyun.com/pypi/packages/0f/dd/84f10e23edd882c6f968c21c2434fe67bd4a528967067515feca9e611e5e/tzdata-2025.1-py2.py3-none-any.whl", hash = "sha256:7e127113816800496f027041c570f50bcd464a020098a3b6b199517772303639" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- 感谢您的贡献! 请你先阅读 贡献指南 https://github.com/langfarm/langfarm/blob/main/CONTRIBUTING.md -->

## PR 内容说明：

增加 langfarm-io 模块：

* 读取 langfuse 的 api_keys 和 models 表信息。
* langfuse 授权方法。


## 相关的 issue

Closes #4

## 确认

在提出此拉取请求时，我确认了以下几点（请复选框）：
<!-- [x] 表示勾选了 -->

- [x] 我已阅读并理解[贡献指南](https://github.com/langfarm/langfarm/blob/main/CONTRIBUTING.md)。
- [x] 我已检查没有与此请求重复的拉取请求。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我已经运行 `poe all` （fmt、lint、pyright、test）通过了。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。
