### PR TITLE
fix: 使用 vitepress base 来适应 github pages

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -6,6 +6,7 @@ import { zh_theme_config, en_theme_config } from './theme-config.mts'
 export default defineConfig({
   title: "Langfarm",
   description: "Langfarm 是 LLM 的应用 DevOps 平台",
+  base: '/langfarm/',
   sitemap: {
     hostname: 'https://langfarm.github.io'
   },


### PR DESCRIPTION
<!-- 感谢您的贡献! 请你先阅读 贡献指南 https://github.com/langfarm/langfarm/blob/main/CONTRIBUTING.md -->

## PR 内容说明：

github pages 部署后会加上项目名

url 的格式为 https://langfarm.github.io/langfarm/

## 相关的 issue

无

## 确认

在提出此拉取请求时，我确认了以下几点（请复选框）：
<!-- [x] 表示勾选了 -->

- [x] 我已阅读并理解[贡献指南](https://github.com/langfarm/langfarm/blob/main/CONTRIBUTING.md)。
- [x] 我已检查没有与此请求重复的拉取请求。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我已经运行 `poe all` （fmt、lint、pyright、test）通过了。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。
